### PR TITLE
Clear cache on LuasnipCleanup autocmd

### DIFF
--- a/after/plugin/cmp_luasnip.vim
+++ b/after/plugin/cmp_luasnip.vim
@@ -1,0 +1,4 @@
+augroup cmp_luasnip
+	au!
+	autocmd User LuasnipCleanup lua require'cmp_luasnip'.clear_cache()
+augroup END

--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -6,6 +6,11 @@ local source = {}
 local snip_cache = {}
 local doc_cache = {}
 
+source.clear_cache = function()
+	snip_cache = {}
+	doc_cache = {}
+end
+
 local function get_documentation(snip, data)
 	local header = (snip.name or "") .. " _ `[" .. data.filetype .. "]`\n"
 	local docstring = { "", "```" .. vim.bo.filetype, snip:get_docstring(), "```" }


### PR DESCRIPTION
Luasnip emits the `LuasnipCleanup` User event when the snippets are reloaded. We should clear the cached snippets on this event.

This way user can put `ls.cleanup()` in their snippets file and reload the file. Their changes will be reflected in completions.